### PR TITLE
#169817544 User can logout /sign out

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -70,6 +70,20 @@ class AuthController {
     ResponseService.setSuccess(200, 'Successfully logged in', token);
     ResponseService.send(res);
   }
+
+  /**
+   * @description logs out a user
+   *
+   * @param {object} req request from body to log out
+   * @param {object} res response to the body
+   * @returns {object} @memberof AuthController
+   */
+  static async logout(req, res) {
+    const token = null;
+    await UserService.updateUser({ id: req.userData.id }, { token });
+    ResponseService.setSuccess(200, 'Successful logout');
+    return ResponseService.send(res);
+  }
 }
 
 export default AuthController;

--- a/src/routes/auth.route.js
+++ b/src/routes/auth.route.js
@@ -9,6 +9,7 @@ const router = express.Router();
 
 router.post('/signup', validateSignup, authController.signUp); // API route for user to signup
 router.post('/login', validateLogin, checkUserExist, authController.login); // API route for user to login
+router.post('/logout', checkUserLoggedIn, authController.logout); // API for logout
 router.get('/protected', checkUserLoggedIn, (req, res) => {
   res.status(200).send('Welcome to the protected route');
 });

--- a/src/services/response.service.js
+++ b/src/services/response.service.js
@@ -38,7 +38,7 @@ export default class ResponseService {
      */
   static send(res) {
     const result = {
-      status: this.type,
+      status: this.statusCode,
       message: this.message,
       data: this.data,
     };

--- a/src/swagger/auth.swagger.js
+++ b/src/swagger/auth.swagger.js
@@ -104,3 +104,50 @@
  *       '401':
  *         description: Incorrect credentials.
  */
+/**
+ * @swagger
+ * /api/auth/logout:
+ *   post:
+ *     tags:
+ *       - User
+ *     name: Logout
+ *     summary: Logs out a user from system
+ *     parameters:
+ *       - name: authorization
+ *         in: header
+ *         schema:
+ *           type: string
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Succesful
+ *       '401':
+ *         description: No Token supplied
+ */
+/**
+ * @swagger
+ * /api/auth/protected:
+ *   get:
+ *     tags:
+ *       - User
+ *     name: Protected
+ *     summary: Protected route that can be accessed only by logged in user
+ *     parameters:
+ *       - name: authorization
+ *         in: header
+ *         schema:
+ *           type: string
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Succesful
+ *       '401':
+ *         description: No Token supplied
+ *
+ */

--- a/src/tests/auth/logout.test.js
+++ b/src/tests/auth/logout.test.js
@@ -1,0 +1,34 @@
+import chaiHttp from 'chai-http';
+import chai, { expect } from 'chai';
+import app from '../../app';
+import { loggedInToken, createUsers } from '../fixtures/users.fixture';
+
+chai.use(chaiHttp);
+describe('Tests for user logout', () => {
+  before(async () => {
+    await createUsers();
+  });
+  it('Should logout a user', (done) => {
+    chai.request(app)
+      .post('/api/auth/logout')
+      .set('Authorization', loggedInToken)
+      .end((error, response) => {
+        expect(response).to.have.status(200);
+        expect(response.body).to.have.property('message')
+          .that.contain('Successful logout');
+        done(error);
+      });
+  });
+  it('Should not allow access to protected route after log out', (done) => {
+    chai.request(app)
+      .get('/api/auth/protected')
+      .set('Authorization', loggedInToken)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('message')
+          .that.contain('Unauthorized access. Invalid token for this user');
+        done(err);
+      });
+  });
+});

--- a/src/tests/fixtures/users.fixture.js
+++ b/src/tests/fixtures/users.fixture.js
@@ -63,6 +63,7 @@ export const loggedInToken = JwtService.generateToken({
 });
 
 export const createUsers = async () => {
+  await Users.destroy({ where: {} });
   await Users.create(activeUser);
   await Users.create({ ...loggedInUser, token: loggedInToken });
 };


### PR DESCRIPTION
#### What does this PR do?
`User can log out`
#### Description of Task to be completed?
```
User can log out and he shouldn't able to use the same token unless he signs in again
```
#### How should this be manually tested?
clone this `repo`
switch to this `branch`
Open `postman`
logout a user then by visiting `api/auth/logout` you will need to provide a token for a logged in user
#### Any background context you want to provide?
Because we don't use a session-based system, and Jwt doesn't have a function to disable the tokens, we are holding the token in db, and check if there is token before a user can access protected route. and delete the token on logout
#### What are the relevant pivotal tracker stories?
`#169817544`
#### Screenshots (if appropriate)
#### Questions: