### PR TITLE
#170600818 apply route naming convention

### DIFF
--- a/src/migrations/20191218075931-create-users.js
+++ b/src/migrations/20191218075931-create-users.js
@@ -64,9 +64,6 @@ export function up(queryInterface, Sequelize) {
       type: Sequelize.BOOLEAN,
       defaultValue: false
     },
-    lineManagerId: {
-      type: Sequelize.INTEGER
-    },
     token: {
       allowNull: true,
       type: Sequelize.STRING

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -15,7 +15,6 @@ export default (sequelize, DataTypes) => {
     profilePicture: DataTypes.STRING(1234),
     token: DataTypes.STRING,
     isVerified: DataTypes.BOOLEAN,
-    lineManagerId: DataTypes.INTEGER
   }, {});
   Users.associate = (models) => {
     // associations can be defined here

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,7 +8,7 @@ const app = express();
 
 app.use('/api/auth', authRoute);
 app.use('/api/', tripRoute);
-app.use('/api/', profileSettingsRoute);
 app.use('/api/accommodations', accommodationRoute);
+app.use('/api/users', profileSettingsRoute);
 
 export default app;

--- a/src/swagger/user-profile-settings.swagger.js
+++ b/src/swagger/user-profile-settings.swagger.js
@@ -16,13 +16,11 @@
  *         type: string
  *       department:
  *         type: string
- *       lineManager:
- *         type: string
  */
 
 /**
  * @swagger
- * /api/view-profile:
+ * /api/users/view-profile:
  *   get:
  *     tags:
  *       - User
@@ -48,7 +46,7 @@
 
 /**
  * @swagger
- * /api/edit-profile:
+ * /api/users/edit-profile:
  *   patch:
  *     tags:
  *       - User
@@ -81,7 +79,7 @@
  *               type: string
  *             department:
  *               type: string
- *             lineManager:
+ *             profilePicture:
  *               type: string
  *     responses:
  *       '200':

--- a/src/tests/profile/profile.test.js
+++ b/src/tests/profile/profile.test.js
@@ -12,7 +12,7 @@ describe('Test for User Account Profile:', () => {
   });
   it('It should allow user to view profile', (done) => {
     chai.request(app)
-      .get('/api/view-profile')
+      .get('/api/users/view-profile')
       .set('Authorization', loggedInToken)
       .end((err, res) => {
         res.body.should.be.an('object');
@@ -33,7 +33,7 @@ describe('Test for User Account Profile:', () => {
 
   it('It should NOT allow user to view profile: Wrong Token Provided', (done) => {
     chai.request(app)
-      .get('/api/view-profile')
+      .get('/api/users/view-profile')
       .set('Authorization', wrongToken)
       .end((err, res) => {
         res.body.should.be.an('object');
@@ -45,7 +45,7 @@ describe('Test for User Account Profile:', () => {
 
   it('It should allow user to edit profile', (done) => {
     chai.request(app)
-      .patch('/api/edit-profile')
+      .patch('/api/users/edit-profile')
       .set('Authorization', loggedInToken, 'Accept', 'application/json')
       .send(userData)
       .end((err, res) => {
@@ -70,7 +70,7 @@ describe('Test for User Account Profile:', () => {
     const userGender = '';
     userData.gender = userGender;
     chai.request(app)
-      .patch('/api/edit-profile')
+      .patch('/api/users/edit-profile')
       .set('Authorization', loggedInToken, 'Accept', 'application/json')
       .send(userData)
       .end((err, res) => {


### PR DESCRIPTION
#### What does this PR do?
`Apply routes naming convention`
#### Description of Task to be completed?
`To create a user account profile page settings feature by allowing a user to be able to view and edit his/her profile` and renaming routes to `/api/users/view-profile` and `/api/users/edit-profile`
#### How should this be manually tested?
* Clone this repo
* Navigate in the repo root using `CMD` or any `TERMINAL`
* Install all packages using `npm install`
* Type `npm run dev` for Postman testing And `npm run test` for mocha testing
* Open postman choose GET and type `localhost:3000/api/users/view-profile` to view profile or                PATCH `localhost:3000/api/users/edit-profile` to edit profile
* Click `body` then `x-www-form-urlencoded`
* Fill in all values you want to edit from the profile for all or some of the following properties: `gender, birthDate, residence, department, preferredLanguage, preferredCurrency, lineManager`
* Click `SEND` on the top right corner of Postman

#### What are the relevant pivotal tracker stories?
- [#169817545](https://www.pivotaltracker.com/story/show/169817545)

#### Screenshots (if appropriate)
`Postman screenshot on View Profile endpoint`
![image](https://user-images.githubusercontent.com/58309608/71622926-cb7fae80-2be1-11ea-8eb1-4b6b16536610.png)


`Postman screenshot on Edit Profile endpoint`
![image](https://user-images.githubusercontent.com/58309608/71622989-21545680-2be2-11ea-96ef-b5fc4da869df.png)


