### PR TITLE
#169817572 like/unlike accommodation facility 

### DIFF
--- a/src/controllers/accommodation.controller.js
+++ b/src/controllers/accommodation.controller.js
@@ -1,5 +1,6 @@
 import AccommodationService from '../services/accommodation.service';
 import ResponseService from '../services/response.service';
+import LikesService from '../services/likes.service';
 
 /**
  *
@@ -27,6 +28,11 @@ class AccommodationController {
       { accommodationId: req.params.accommodationId, id: req.params.roomId },
       { availableRooms: req.availableRooms - 1 }
     );
+    await AccommodationService.createAccommodationReaction({
+      accommodationId: req.params.accommodationId,
+      roomId: req.params.roomId,
+      userId: req.userData.id
+    });
     ResponseService.setSuccess(201, 'Accommodation is successfully booked', dataValues);
     return ResponseService.send(res);
   }
@@ -74,6 +80,64 @@ class AccommodationController {
 
     ResponseService.setSuccess(201, 'Accommodation is successfully created', newAccommodation);
     return ResponseService.send(res);
+  }
+
+  /**
+     *
+     * @static
+     * @param {req} req
+     * @param {res} res
+     * @returns {response} @memberof AccommodationController
+     */
+  static async updateAccommodationReaction(req, res) {
+    let like;
+    let unlike;
+    if (req.body.like === 'yes') {
+      like = true;
+    } else {
+      like = false;
+    }
+    if (req.body.unlike === 'yes') {
+      unlike = true;
+    } else {
+      unlike = false;
+    }
+    if ((like === true && unlike === true) || (like === false && unlike === false)) {
+      ResponseService.setError(400, 'Like and unlike must have different values');
+      ResponseService.send(res);
+    } else {
+      const { accommodationId, roomId } = req.params;
+      const userId = req.userData.id;
+      const reactionRecord = await LikesService.findReactionRecordByProperty({
+        accommodationId, userId, roomId
+      });
+      if ((reactionRecord.like) === true && like === true) like = false;
+      if (reactionRecord.unlike === true && unlike === true) unlike = false;
+      const [, [{ dataValues }]] = await LikesService.updateALike({
+        accommodationId, userId, roomId
+      }, { like, unlike });
+      ResponseService.setSuccess(200, 'Reaction updated successfully', dataValues);
+      ResponseService.send(res);
+    }
+  }
+
+  /**
+ *
+ *
+ * @static
+ * @param {req} req
+ * @param {res} res
+ * @returns {response} @memberof AccommodationController
+ */
+  static async countReactionsOnAccommodation(req, res) {
+    const likesCount = await AccommodationService.findAccommodationReactionRecordByProperty({
+      accommodationId: req.params.accommodationId, like: true
+    });
+    const unlikesCount = await AccommodationService.findAccommodationReactionRecordByProperty({
+      accommodationId: req.params.accommodationId, unlike: true
+    });
+    ResponseService.setSuccess(200, 'Reaction records successfully retrieved', { likes: likesCount.length, dislikes: unlikesCount.length });
+    ResponseService.send(res);
   }
 }
 

--- a/src/controllers/accommodation.controller.js
+++ b/src/controllers/accommodation.controller.js
@@ -90,35 +90,20 @@ class AccommodationController {
      * @returns {response} @memberof AccommodationController
      */
   static async updateAccommodationReaction(req, res) {
-    let like;
-    let unlike;
-    if (req.body.like === 'yes') {
-      like = true;
-    } else {
-      like = false;
-    }
-    if (req.body.unlike === 'yes') {
-      unlike = true;
-    } else {
-      unlike = false;
-    }
-    if ((like === true && unlike === true) || (like === false && unlike === false)) {
-      ResponseService.setError(400, 'Like and unlike must have different values');
-      ResponseService.send(res);
-    } else {
-      const { accommodationId, roomId } = req.params;
-      const userId = req.userData.id;
-      const reactionRecord = await LikesService.findReactionRecordByProperty({
-        accommodationId, userId, roomId
-      });
-      if ((reactionRecord.like) === true && like === true) like = false;
-      if (reactionRecord.unlike === true && unlike === true) unlike = false;
-      const [, [{ dataValues }]] = await LikesService.updateALike({
-        accommodationId, userId, roomId
-      }, { like, unlike });
-      ResponseService.setSuccess(200, 'Reaction updated successfully', dataValues);
-      ResponseService.send(res);
-    }
+    let like = req.like;
+    let unlike = req.unlike;
+    const { accommodationId, roomId } = req.params;
+    const userId = req.userData.id;
+    const reactionRecord = await LikesService.findReactionRecordByProperty({
+      accommodationId, userId, roomId
+    });
+    if (like === true && (reactionRecord.like) === like) like = !reactionRecord.like;
+    if (unlike === true && reactionRecord.unlike === unlike) unlike = !reactionRecord.unlike;
+    const [, [{ dataValues }]] = await LikesService.updateALike({
+      accommodationId, userId, roomId
+    }, { like, unlike });
+    ResponseService.setSuccess(200, 'Reaction updated successfully', dataValues);
+    ResponseService.send(res);
   }
 
   /**

--- a/src/middlewares/accommodation.middleware.js
+++ b/src/middlewares/accommodation.middleware.js
@@ -2,6 +2,7 @@ import { Op } from 'sequelize';
 import LocationService from '../services/location.service';
 import ResponseService from '../services/response.service';
 import AccommodationService from '../services/accommodation.service';
+import BookingService from '../services/booking.service';
 
 
 export const checkIfAccommodationTypeExists = async (req, res, next) => {
@@ -87,3 +88,20 @@ export const checkPermission = async (req, res, next) => {
     ResponseService.send(res);
   }
 };
+
+const accommodationMiddleware = {
+  checkBookingExist: async (req, res, next) => {
+    const findBooking = await BookingService.findBookingByProperty({
+      accommodationId: req.params.accommodationId,
+      roomId: req.params.roomId,
+      userId: req.userData.id
+    });
+    if (!findBooking) {
+      ResponseService.setError(404, 'Accommodation booking not found');
+      return ResponseService.send(res);
+    }
+    next();
+  },
+};
+
+export default accommodationMiddleware;

--- a/src/middlewares/accommodation.middleware.js
+++ b/src/middlewares/accommodation.middleware.js
@@ -42,17 +42,18 @@ export const checkAvailability = async (req, res, next) => {
   const searchResult = await AccommodationService
     .findAccommodationWithInclude(
       req.params.accommodationId,
-      { include: [
-        {
-          association: 'rooms',
-          where: {
-            id: req.params.roomId,
-            availableRooms: {
-              [Op.gt]: 0
+      {
+        include: [
+          {
+            association: 'rooms',
+            where: {
+              id: req.params.roomId,
+              availableRooms: {
+                [Op.gt]: 0
+              }
             }
           }
-        }
-      ]
+        ]
       }
     );
 
@@ -68,7 +69,8 @@ export const checkAvailability = async (req, res, next) => {
 
 export const checkPermission = async (req, res, next) => {
   const searchResult = await AccommodationService
-    .findBookingByProperty({ userId: req.userData.id,
+    .findBookingByProperty({
+      userId: req.userData.id,
       roomId: req.params.roomId,
       [Op.or]: [{
         from: {
@@ -91,12 +93,15 @@ export const checkPermission = async (req, res, next) => {
 
 const accommodationMiddleware = {
   checkBookingExist: async (req, res, next) => {
-    const findBooking = await BookingService.findBookingByProperty({
+    const bookingData = await BookingService.findBookingByProperty({
       accommodationId: req.params.accommodationId,
       roomId: req.params.roomId,
       userId: req.userData.id
     });
-    if (!findBooking) {
+    if (bookingData) {
+      req.bookingData = bookingData;
+    }
+    if (!bookingData) {
       ResponseService.setError(404, 'Accommodation booking not found');
       return ResponseService.send(res);
     }
@@ -115,13 +120,15 @@ const accommodationMiddleware = {
     } else {
       unlike = false;
     }
-    if ((like === unlike)) {
+    if (like !== unlike) {
+      req.likeValue = like;
+      req.unlikeValue = unlike;
+    }
+    if ((like === true && unlike === true) || (like === false && unlike === false)) {
       ResponseService.setError(400, 'Like and unlike must have different values');
       ResponseService.send(res);
     }
     next();
-    like = req.like;
-    unlike = req.unlike;
   },
 };
 

--- a/src/middlewares/accommodation.middleware.js
+++ b/src/middlewares/accommodation.middleware.js
@@ -102,6 +102,27 @@ const accommodationMiddleware = {
     }
     next();
   },
+  checkIfLikeUnlikeAreSame: async (req, res, next) => {
+    let like;
+    let unlike;
+    if (req.body.like === 'yes') {
+      like = true;
+    } else {
+      like = false;
+    }
+    if (req.body.unlike === 'yes') {
+      unlike = true;
+    } else {
+      unlike = false;
+    }
+    if ((like === unlike)) {
+      ResponseService.setError(400, 'Like and unlike must have different values');
+      ResponseService.send(res);
+    }
+    next();
+    like = req.like;
+    unlike = req.unlike;
+  },
 };
 
 export default accommodationMiddleware;

--- a/src/migrations/20200115164146-create-rooms.js
+++ b/src/migrations/20200115164146-create-rooms.js
@@ -21,6 +21,12 @@ export const up = (queryInterface, Sequelize) => queryInterface.createTable('Roo
   roomPrice: {
     type: Sequelize.DECIMAL(10, 2)
   },
+  likesCount: {
+    type: Sequelize.INTEGER
+  },
+  dislikesCount: {
+    type: Sequelize.INTEGER
+  },
   createdAt: {
     allowNull: false,
     type: Sequelize.DATE

--- a/src/migrations/20200119150631-create-likes.js
+++ b/src/migrations/20200119150631-create-likes.js
@@ -1,0 +1,39 @@
+export const up = (queryInterface, Sequelize) => queryInterface.createTable('likes', {
+  id: {
+    allowNull: false,
+    autoIncrement: true,
+    primaryKey: true,
+    type: Sequelize.INTEGER
+  },
+  accommodationId: {
+    type: Sequelize.INTEGER
+  },
+  userId: {
+    type: Sequelize.INTEGER
+  },
+  roomId: {
+    type: Sequelize.INTEGER
+  },
+  like: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
+  },
+  unlike: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
+  },
+  createdAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  }
+});
+/**
+ * @exports
+ * @class
+ * @param {object} queryInterface
+ */
+export function down(queryInterface) { return queryInterface.dropTable('likes'); }

--- a/src/models/likes.js
+++ b/src/models/likes.js
@@ -1,0 +1,10 @@
+export default (sequelize, DataTypes) => {
+  const likes = sequelize.define('likes', {
+    accommodationId: DataTypes.INTEGER,
+    userId: DataTypes.INTEGER,
+    roomId: DataTypes.INTEGER,
+    like: DataTypes.BOOLEAN,
+    unlike: DataTypes.BOOLEAN
+  }, {});
+  return likes;
+};

--- a/src/models/rooms.js
+++ b/src/models/rooms.js
@@ -13,7 +13,9 @@ export default (sequelize, DataTypes) => {
     numberOfPeople: DataTypes.INTEGER,
     numberOfRooms: DataTypes.INTEGER,
     availableRooms: DataTypes.INTEGER,
-    roomPrice: DataTypes.DECIMAL(10, 2)
+    roomPrice: DataTypes.DECIMAL(10, 2),
+    likesCount: DataTypes.INTEGER,
+    dislikesCount: DataTypes.INTEGER
   }, {});
   Rooms.associate = (models) => {
     // associations can be defined here

--- a/src/routes/accommodation.route.js
+++ b/src/routes/accommodation.route.js
@@ -1,8 +1,12 @@
 import express from 'express';
 import authMiddleware from '../middlewares/auth.middleware';
 import AccommodationController from '../controllers/accommodation.controller';
-import { bookAccommodationValidation, createAccommodationValidations } from '../validations/accommodation.validation';
-import { checkIfAccommodationTypeExists,
+import {
+  bookAccommodationValidation,
+  createAccommodationValidations,
+  validateAccommodationReaction
+} from '../validations/accommodation.validation';
+import accommodationMiddleware, { checkIfAccommodationTypeExists,
   checkIfLocationExists,
   avoidDuplicateAccommodation,
   checkPermission,
@@ -26,6 +30,17 @@ router.post(
   checkIfAccommodationTypeExists, checkIfLocationExists,
   AccommodationController.createAccommodation
 );
-
-
+router.patch(
+  '/:accommodationId/rooms/:roomId/react',
+  authMiddleware.checkUserLoggedIn,
+  validateAccommodationReaction,
+  accommodationMiddleware.checkBookingExist,
+  AccommodationController.updateAccommodationReaction
+);
+router.get(
+  '/:accommodationId/rooms/:roomId/reactions-count',
+  authMiddleware.checkUserLoggedIn,
+  accommodationMiddleware.checkBookingExist,
+  AccommodationController.countReactionsOnAccommodation
+);
 export default router;

--- a/src/routes/accommodation.route.js
+++ b/src/routes/accommodation.route.js
@@ -35,6 +35,7 @@ router.patch(
   authMiddleware.checkUserLoggedIn,
   validateAccommodationReaction,
   accommodationMiddleware.checkBookingExist,
+  accommodationMiddleware.checkIfLikeUnlikeAreSame,
   AccommodationController.updateAccommodationReaction
 );
 router.get(

--- a/src/services/accommodation.service.js
+++ b/src/services/accommodation.service.js
@@ -1,7 +1,7 @@
 import models from '../models';
 
 
-const { Accommodation, Booking, AccommodationType, Rooms, Users } = models;
+const { Accommodation, Booking, AccommodationType, Rooms, Users, likes } = models;
 
 /**
  *
@@ -132,6 +132,29 @@ class AccommodationService {
   static findBookingByProperty(property) {
     return Booking.findAll({
       where: property
+    });
+  }
+
+  /**
+       *
+       *
+       * @static
+       * @param {newAccommodationLike} newAccommodationLike
+       * @returns {newAccommodationLike} @memberof AccommodationService
+       */
+  static createAccommodationReaction(newAccommodationLike) {
+    return likes.create(newAccommodationLike);
+  }
+
+  /** find accommodation by property
+* @static
+* @param {object} property
+* @memberof AccommodationService
+* @returns {object} data
+*/
+  static findAccommodationReactionRecordByProperty(property) {
+    return likes.findAll({
+      where: { ...property }
     });
   }
 }

--- a/src/services/accommodation.service.js
+++ b/src/services/accommodation.service.js
@@ -107,6 +107,19 @@ class AccommodationService {
   }
 
   /**
+ * find ~Room
+ * @static
+ * @param {object} property
+ * @memberof AccommodationService
+ * @returns {object} data
+ */
+  static findRoomByProperty(property) {
+    return Rooms.findOne({
+      where: property
+    });
+  }
+
+  /**
    * Update
    * @static
    * @param {object} condition

--- a/src/services/booking.service.js
+++ b/src/services/booking.service.js
@@ -1,0 +1,25 @@
+import models from '../models';
+
+const { Booking } = models;
+
+/**
+ *
+ *
+ * @class BookingService
+ */
+class BookingService {
+  /**
+       * find Accommodation Booking
+       * @static
+       * @param {object} property
+       * @memberof BookingService
+       * @returns {object} data
+       */
+  static findBookingByProperty(property) {
+    return Booking.findOne({
+      where: property
+    });
+  }
+}
+
+export default BookingService;

--- a/src/services/likes.service.js
+++ b/src/services/likes.service.js
@@ -1,0 +1,38 @@
+import models from '../models';
+
+const { likes } = models;
+
+/**
+ *
+ *
+ * @class LikesService
+ */
+class LikesService {
+  /**
+       * find a like
+       * @static
+       * @param {object} property
+       * @memberof LikesService
+       * @returns {object} data
+       */
+  static findReactionRecordByProperty(property) {
+    return likes.findOne({
+      where: { ...property }
+    });
+  }
+
+  /**
+ * Update a like
+ * @param {object} like
+ * @param {object} likeInfo
+ * @returns {object} updated object.
+ */
+  static updateALike(like, likeInfo) {
+    return likes.update(likeInfo, {
+      where: like,
+      returning: true
+    });
+  }
+}
+
+export default LikesService;

--- a/src/swagger/accommodation.swagger.js
+++ b/src/swagger/accommodation.swagger.js
@@ -187,3 +187,97 @@
  *       '401':
  *         description: No valid token supplied
  */
+
+/**
+* @swagger
+* definitions:
+*   React On Booked Accommodation:
+*     type: object
+*     properties:
+*       like:
+*         type: string
+*       unlike:
+*         type: string
+*     required:
+*         - like
+*         - unlike
+*/
+/**
+ * @swagger
+ * /api/accommodations/{accommodationId}/rooms/{roomId}/react:
+ *   patch:
+ *     tags:
+ *       - accommodation
+ *     name: Accommodation Likes
+ *     summary: A user should be able to like or unlike on a booked accommodation facility
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - name: authorization
+ *         in: header
+ *         schema:
+ *              type: string
+ *       - name: accommodationId
+ *         in: path
+*       - name: roomId
+ *         in: path
+ *       - name: body
+ *         in: body
+ *         schema:
+ *           $ref: '#/definitions/React On Booked Accommodation'
+ *           type: object
+ *           like:
+ *              type: string
+ *           unlike:
+ *              type: string
+ *         required:
+ *              - like
+ *              - unlike
+ *     responses:
+ *       '200':
+ *         description: Reaction updated successfully
+ *       '400':
+ *         description: Invalid inputs
+ *       '401':
+ *         description: No Token supplied
+ *       '403':
+ *         description: Forbidden
+ *       '404':
+ *         description: Accommodation booking not found
+ */
+
+/**
+ * @swagger
+ * /api/accommodations/{accommodationId}/rooms/{roomId}/reactions-count:
+ *   get:
+ *     tags:
+ *       - accommodation
+ *     name: Accommodation Reactions Count
+ *     summary: A user should be able get count of both likes and dislikes on specific accommodation
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - name: authorization
+ *         in: header
+ *         schema:
+ *              type: string
+ *       - name: accommodationId
+ *         in: path
+*       - name: roomId
+ *         in: path
+ *     responses:
+ *       '200':
+ *         description: Reaction records successfully retrieved
+ *       '400':
+ *         description: Invalid inputs
+ *       '401':
+ *         description: No Token supplied
+ *       '403':
+ *         description: Forbidden
+ *       '404':
+ *         description: Accommodation booking not found
+ */

--- a/src/tests/accomodation/accommodation.test.js
+++ b/src/tests/accomodation/accommodation.test.js
@@ -6,7 +6,14 @@ import { booking,
   createTravelAdmin,
   travelAdminToken,
   newAccomodation,
-  crateMultipleAccommodations } from '../fixtures/accommodation.fixture';
+  crateMultipleAccommodations,
+  createNewBooking,
+  newBooking,
+  accommodationReactionValue,
+  invalidAccommodationId,
+  accommodationWrongReactionValue,
+  createAccommodationReactionRecord,
+  accommodationSameReactionValue } from '../fixtures/accommodation.fixture';
 import { loggedInToken, createUsers } from '../fixtures/users.fixture';
 import cleanAllTables from '../fixtures/database.fixture';
 
@@ -202,6 +209,134 @@ describe('Create accommmodation', () => {
         expect(res).to.have.status(404);
         expect(res.body).to.have.property('message');
         expect(res.body.message).eqls('Accomodation type you specified doesn\'t exists');
+        done();
+      });
+  });
+});
+
+describe('Test On User Like/Unlike Booked Accommodation:', () => {
+  before(async () => {
+    await createNewBooking();
+    await createAccommodationReactionRecord();
+  });
+  it('Should return status code 200 once an accommodation is successfully reacted on(Like)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send(accommodationReactionValue)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(200);
+        res.body.should.have.property('message').equal('Reaction updated successfully');
+        done();
+      });
+  });
+
+  it('Should return status code 200 once an accommodation is successfully re-liked(Remove a like)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send(accommodationReactionValue)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(200);
+        res.body.should.have.property('message').equal('Reaction updated successfully');
+        done();
+      });
+  });
+
+  it('Should return status code 200 once an accommodation is successfully reacted on(Dislike)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send({ like: 'no', unlike: 'yes' })
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(200);
+        res.body.should.have.property('message').equal('Reaction updated successfully');
+        done();
+      });
+  });
+
+  it('Should return status code 200 once an accommodation is successfully re-disliked(Remove a dislike)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send({ like: 'no', unlike: 'yes' })
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(200);
+        res.body.should.have.property('message').equal('Reaction updated successfully');
+        done();
+      });
+  });
+
+  it('Should return status code 404 once accommodation booking is not available', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${invalidAccommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send(accommodationReactionValue)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(404);
+        res.body.should.have.property('message').equal('Accommodation booking not found');
+        done();
+      });
+  });
+
+  it('Should return status code 400 once like and unlike input values are same (Yes)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send(accommodationSameReactionValue)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(400);
+        res.body.should.have.property('message').equal('Like and unlike must have different values');
+        done();
+      });
+  });
+
+  it('Should return status code 400 once like and unlike input values are same (No)', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send({ like: 'no', unlike: 'no' })
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(400);
+        res.body.should.have.property('message').equal('Like and unlike must have different values');
+        done();
+      });
+  });
+
+  it('Should return status code 400 upon invalid input data: like must be one of yes no', (done) => {
+    chai.request(app)
+      .patch(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/react`)
+      .set('Authorization', loggedInToken)
+      .send(accommodationWrongReactionValue)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(400);
+        res.body.should.have.property('message');
+        res.body.message[0].should.be.equal('like must be one of yes no');
+        done();
+      });
+  });
+});
+
+describe('Test On Get Accommodation Reactions Count:', () => {
+  it('Should return status code 200 once an accommodation reactions count is successfully retrieved', (done) => {
+    chai.request(app)
+      .get(`/api/accommodations/${newBooking.accommodationId}/rooms/${newBooking.roomId}/reactions-count`)
+      .set('Authorization', loggedInToken)
+      .end((err, res) => {
+        res.body.should.be.an('object');
+        res.should.have.status(200);
+        res.body.should.have.property('message').equal('Reaction records successfully retrieved');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('likes');
+        res.body.data.should.have.property('dislikes');
         done();
       });
   });

--- a/src/tests/fixtures/accommodation.fixture.js
+++ b/src/tests/fixtures/accommodation.fixture.js
@@ -2,9 +2,9 @@ import faker from 'faker';
 import BcryptService from '../../services/bcrypt.service';
 import JwtService from '../../services/jwt.service';
 import models from '../../models';
-import { defaultPreferences } from './users.fixture';
+import { defaultPreferences, loggedInUser } from './users.fixture';
 
-const { Users, Preferences, Accommodation } = models;
+const { Users, Preferences, Accommodation, Booking, likes } = models;
 
 const fakerDate1 = faker.date.future(2);
 const month1 = (`0${fakerDate1.getMonth() + 1}`).slice(-2);
@@ -139,3 +139,45 @@ export const createTravelAdmin = async () => {
   await Users.create({ ...travelAdmin, token: travelAdminToken });
   await Preferences.create({ ...defaultPreferences, userId: travelAdmin.id });
 };
+export const newBooking = {
+  ...booking,
+  userId: loggedInUser.id,
+  accommodationId: 1,
+  roomId: faker.random.number({ min: 1, max: 3 })
+};
+export const accommodationReactionRecord = {
+  accommodationId: newBooking.accommodationId,
+  userId: newBooking.userId,
+  roomId: newBooking.roomId,
+  like: false,
+  unlike: false
+};
+
+export const createAccommodationReactionRecord = async () => {
+  await likes.destroy({ where: {} });
+  await likes.create(accommodationReactionRecord);
+};
+
+export const createNewBooking = async () => {
+  await Booking.destroy({ where: {} });
+  await Booking.create(newBooking);
+};
+
+export const accommodationReactionValue = {
+  like: 'yes',
+  unlike: 'no'
+};
+
+export const accommodationWrongReactionValue = {
+  ...accommodationReactionValue,
+  like: faker.random.number({ min: 1, max: 20 })
+};
+
+export const accommodationSameReactionValue = {
+  ...accommodationReactionValue,
+  unlike: 'yes'
+};
+
+export const invalidAccommodationId = faker.random.number({ min: 200000, max: 200001 });
+
+export default booking;

--- a/src/validations/accommodation.validation.js
+++ b/src/validations/accommodation.validation.js
@@ -1,7 +1,7 @@
 import joiBase from '@hapi/joi';
 import joiDate from '@hapi/joi-date';
-import Response from '../services/response.service';
 import transformErrorHandler from '../helpers/transformErrorHandler';
+import ResponseService from '../services/response.service';
 
 const Joi = joiBase.extend(joiDate);
 
@@ -28,8 +28,8 @@ export const bookAccommodationValidation = async (req, res, next) => {
   const results = schema.validate({ ...req.body, ...req.params });
   if (results.error) {
     const errorMessages = results.error.details.map((error) => error.message.replace(/[^a-zA-Z0-9 .-]/g, ''));
-    Response.setError(400, errorMessages);
-    return Response.send(res);
+    ResponseService.setError(400, errorMessages);
+    return ResponseService.send(res);
   }
   next();
 };
@@ -181,4 +181,38 @@ export const createAccommodationValidations = async (req, res, next) => {
   }).options({ abortEarly: false });
 
   transformErrorHandler(createAccommodationSchema, req.body, res, next);
+};
+
+const likeAndUnlikeAccommodationSchema = Joi.object({
+  like: Joi.boolean()
+    .valid('yes', 'no')
+    .required()
+    .messages({
+      'string.base': 'Invalid type, likeValue must be a string',
+      'string.empty': 'Please enter likeValue',
+      'any.required': 'likeValue is required'
+    }),
+  unlike: Joi.boolean()
+    .valid('yes', 'no')
+    .required()
+    .messages({
+      'string.base': 'Invalid type, dislikeValue must be a string',
+      'string.empty': 'Please enter dislikeValue',
+      'any.required': 'dislikeValue is required'
+    })
+}).options({ abortEarly: false });
+
+const validateHandler = (schema, body, res, next) => {
+  const { error } = schema.validate(body);
+  if (error) {
+    const { details } = error;
+    const errors = details.map(({ message }) => (message.replace(/[^a-zA-Z0-9 .-]/g, '')));
+    ResponseService.setError(400, errors);
+    return ResponseService.send(res);
+  }
+  next();
+};
+
+export const validateAccommodationReaction = (req, res, next) => {
+  validateHandler(likeAndUnlikeAccommodationSchema, req.body, res, next);
 };


### PR DESCRIPTION
 #### What does this PR do?
`like-unlike accommodation facility`
#### Description of Task to be completed?
- `To allow a user to like or unlike an accommodation facility he booked using single endpoint where a user will input values for like and unlike at once`
- Once a user has liked an accommodation facility and likes it again, the previous like will get removed.
- Also `likesCounts` has been added to `Accommodation's room table` in order to easily know likes counts for each room. Once a user likes an accommodation's room the `likesCounts` increases.

#### How should this be manually tested?
* Clone this repo
* Navigate in the repo root using `CMD` or any `TERMINAL`
* Install all packages using `npm install`
* Type `npm run dev` for Postman testing And `npm run test` for mocha testing
* Open postman choose PATCH `localhost:3000/api/accommodations/:accommodationId/rooms/:roomId/react` to like or unlike an 
    accommodation.
* Click `body` then `x-www-form-urlencoded`
* Fill in `like` with `yes` or `no`  and `unlike`  with `yes` or `no`
* Click Headers and Type `Authorization` paste in your `After logging in Token` as value
* Click `SEND` on the top right corner of Postman

#### What are the relevant pivotal tracker stories?
- [#169817572](https://www.pivotaltracker.com/story/show/169817572)

#### Screenshots (if appropriate)
`Postman screenshot`
<img width="1440" alt="Screen Shot 2020-03-23 at 14 48 54" src="https://user-images.githubusercontent.com/58309608/77321183-7c49a580-6d1a-11ea-991f-d4f328e9f948.png">

