### PR TITLE
#171894403 fix bug on origin and destination

### DIFF
--- a/src/middlewares/trip.middleware.js
+++ b/src/middlewares/trip.middleware.js
@@ -45,7 +45,7 @@ class TripMiddleware {
  */
   static async checkOriginDestinationEquality(req, res, next) {
     const { originId, destinationId } = req.body;
-    if (originId === destinationId) {
+    if (originId === destinationId && originId !== undefined && destinationId !== undefined) {
       ResponseService.setError(400, 'Origin and destination must be different');
       return ResponseService.send(res);
     }


### PR DESCRIPTION
 #### What does this PR do?
`Fix bug to allow a user to be able to update an open trip request even if he did not fill in origin and/or destination`
#### Description of Task to be completed?
`Allow a user to submit frontend form data while updating open trip request even if he didn't fill in origin and destination`
#### How should this be manually tested?
* Clone the [Frontend repo](https://github.com/andela/the_spinners-frontend)
* Navigate in the repo root using `CMD` or any `TERMINAL`
* Install all packages using `npm install`
* Type `npm run start-dev` 
* Clone this [Backend repo](https://github.com/andela/the_spinners-backend)
* Run `npm install`
* Run `npm run dev`
* Signup and Login to frontend
* Create a trip by clicking `Book a trip` on the sidebar
* After creating a trip, click on `Trip requests` to view all trips you have created.
* Click `EDIT TRIP` button of a specific trip.
* Fill in only fields you want to update. Test also to update by omitting `origin` and/or `destination` fields
* Click `Update Trip` button

#### What are the relevant pivotal tracker stories?
- [#171894403](https://www.pivotaltracker.com/story/show/171894403)

#### Screenshots (if appropriate)
- Before fixing this bug
<img width="1440" alt="Screen Shot 2020-03-20 at 09 57 10" src="https://user-images.githubusercontent.com/58309608/77145473-52318280-6a91-11ea-8bd4-a4fb42c30aef.png">

- After fixing this bug
<img width="1433" alt="Screen Shot 2020-03-20 at 09 59 29 1" src="https://user-images.githubusercontent.com/58309608/77145536-8311b780-6a91-11ea-9608-2caccab71430.png">



